### PR TITLE
Many performance improvements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ config = {
     'author': 'Pants Contributors',
     'url': 'https://pypi.python.org/pypi/zincutils',
     'author_email': 'pants-devel@groups.google.com',
-    'version': '0.1.1',
+    'version': '0.2',
     'install_requires': ['six'],
     'packages': ['zincutils'],
     'scripts': [],

--- a/tests/test_zinc_analysis.py
+++ b/tests/test_zinc_analysis.py
@@ -67,7 +67,7 @@ class ZincAnalysisTestSimple(ZincAnalysisTestBase):
       analysis_splits = full_analysis.split([
         ['/src/pants/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala'],
         ['/src/pants/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala'],
-      ], os.path.dirname(__file__))
+      ])
       self.assertEquals(len(analysis_splits), 2)
 
       def compare_split(i):
@@ -167,7 +167,7 @@ class ZincAnalysisTestComplex(ZincAnalysisTestBase):
         # Split the merged analysis back to individual analyses.
         sources_per_analysis = [a.stamps.sources.keys() for a in analyses]
         split_analyses = self._time(lambda: merged_analysis2.split(
-            sources_per_analysis, os.path.dirname(__file__), catchall=True),
+          sources_per_analysis, catchall=True),
           'Split back into %d analyses' % num_analyses)
 
         self.assertEquals(num_analyses + 1, len(split_analyses))  # +1 for the catchall.
@@ -282,7 +282,6 @@ class ZincAnalysisTestLarge(ZincAnalysisTestBase):
 
       # Split the merged analysis.
       sources_per_analysis = [a.stamps.sources.keys() for a in analyses]
-      self._time(lambda: merged_analysis.split(sources_per_analysis, os.path.dirname(__file__),
-                                               catchall=True), msg('Split'))
+      self._time(lambda: merged_analysis.split(sources_per_analysis, catchall=True), msg('Split'))
 
     print('Total time: %f seconds' % self.total_time)

--- a/zincutils/contextutil.py
+++ b/zincutils/contextutil.py
@@ -14,12 +14,11 @@ from contextlib import contextmanager
 
 @contextmanager
 def temporary_dir(root_dir=None, cleanup=True):
-  """
-    A with-context that creates a temporary directory.
+  """A with-context that creates a temporary directory.
 
-    You may specify the following keyword args:
-    :param str root_dir: The parent directory to create the temporary directory.
-    :param bool cleanup: Whether or not to clean up the temporary directory.
+  You may specify the following keyword args:
+  :param str root_dir: The parent directory to create the temporary directory.
+  :param bool cleanup: Whether or not to clean up the temporary directory.
   """
   path = tempfile.mkdtemp(dir=root_dir)
   try:
@@ -58,13 +57,12 @@ def environment_as(**kwargs):
 
 
 class Timer(object):
-  """Very basic with-context to time operations
+  """Very basic with-context to time operations.
 
   Example usage:
     from pants.util.contextutil import Timer
     with Timer() as timer:
       time.sleep(2)
-      ...
     timer.elapsed
     2.0020849704742432
 

--- a/zincutils/zinc_analysis.py
+++ b/zincutils/zinc_analysis.py
@@ -81,14 +81,14 @@ class ZincAnalysisElement(object):
     Items are sorted, for ease of testing, only if ZINCUTILS_SORTED_ANALYSIS is set in
     the environment, and is not falsy. The sort is too costly to have in production use.
     """
-    def rebase(bytes):
+    def rebase(buf):
       for rebase_from, rebase_to in rebasings:
         if rebase_to is None:
-          if rebase_from in bytes:
+          if rebase_from in buf:
             return None
         else:
-          bytes = bytes.replace(rebase_from, rebase_to)
-      return bytes
+          buf = buf.replace(rebase_from, rebase_to)
+      return buf
 
     rebasings = rebasings or []
     num_items = 0

--- a/zincutils/zinc_analysis.py
+++ b/zincutils/zinc_analysis.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import itertools
 import os
+import six
 from collections import defaultdict
 
 from zincutils.zinc_analysis_diff import ZincAnalysisElementDiff
@@ -42,14 +43,16 @@ class ZincAnalysisElement(object):
     # 'org/pantsbuild/Foo.scala': ['org/pantsbuild/Foo.class', 'org/pantsbuild/Foo$.class']
     #
     # Subclasses can alias the elements of self.args in their own __init__, for convenience.
-    self.args = []
-    # Sort the values for each key. This consistency makes it easier to test and to
-    # debug live problems in the wild.
-    for arg in args:
-      sorted_arg = defaultdict(list)
-      for k, vs in arg.items():
-        sorted_arg[k] = sorted(vs)
-      self.args.append(sorted_arg)
+
+    if os.environ.get('ZINCUTILS_SORTED_ANALYSIS'):
+      self.args = []
+      for arg in args:
+        sorted_arg = defaultdict(list)
+        for k, vs in arg.items():
+          sorted_arg[k] = sorted(vs)
+        self.args.append(sorted_arg)
+    else:
+      self.args = args
 
   def diff(self, other):
     return ZincAnalysisElementDiff(self, other)
@@ -75,45 +78,69 @@ class ZincAnalysisElement(object):
   def _write_section(self, outfile, header, rep, inline_vals=True, rebasings=None):
     """Write a single section.
 
-    Items are sorted, for ease of testing. TODO: Reconsider this if it hurts performance.
+    Items are sorted, for ease of testing, only if ZINCUTILS_SORTED_ANALYSIS is set in
+    the environment, and is not falsy. The sort is too costly to have in production use.
     """
-    def rebase(txt):
+    def rebase(bytes):
       for rebase_from, rebase_to in rebasings:
         if rebase_to is None:
-          if rebase_from in txt:
+          if rebase_from in bytes:
             return None
         else:
-          txt = txt.replace(rebase_from, rebase_to)
-      return txt
+          bytes = bytes.replace(rebase_from, rebase_to)
+      return bytes
 
     rebasings = rebasings or []
-    items = []
-    for k, vals in rep.items():
-      for v in vals:
-        item = rebase('{} -> {}{}'.format(k, '' if inline_vals else '\n', v))
-        if item:
-          items.append(item)
+    num_items = 0
+    for vals in six.itervalues(rep):
+      num_items += len(vals)
 
-    items.sort()
-    outfile.write(header + ':\n')
-    outfile.write('{} items\n'.format(len(items)))
-    for item in items:
-      outfile.write(item.encode('utf-8'))
-      outfile.write('\n')
+    outfile.write(header + b':\n')
+    outfile.write(b'{} items\n'.format(num_items))
+
+    # Writing in large chunks is significantly faster than rebasing and writing line-by-line.
+    fragments = []
+    def do_write():
+      buf = rebase(b''.join(fragments))
+      outfile.write(buf)
+      del fragments[:]
+
+    if os.environ.get('ZINCUTILS_SORTED_ANALYSIS'):
+      # Write everything in a single chunk, so we can sort.
+      for k, vals in six.iteritems(rep):
+        for v in vals:
+          item = b'{} -> {}{}\n'.format(k, b'' if inline_vals else b'\n', v)
+          fragments.append(item)
+      fragments.sort()
+      do_write()
+    else:
+      # It's not strictly necessary to chunk on item boundaries, but it's nicer.
+      chunk_size = 40000 if inline_vals else 50000
+      for k, vals in six.iteritems(rep):
+        for v in vals:
+          fragments.append(k)
+          fragments.append(b' -> ')
+          if not inline_vals:
+            fragments.append(b'\n')
+          fragments.append(v)
+          fragments.append(b'\n')
+        if len(fragments) >= chunk_size:
+          do_write()
+      do_write()
 
   def translate_keys(self, token_translator, arg):
-    old_keys = list(arg.keys())
+    old_keys = list(six.iterkeys(arg))
     for k in old_keys:
       vals = arg[k]
       del arg[k]
       arg[token_translator.convert(k)] = vals
 
   def translate_values(self, token_translator, arg):
-    for k, vals in arg.iteritems():
+    for k, vals in six.iteritems(arg):
       arg[k] = [token_translator.convert(v) for v in vals]
 
   def translate_base64_values(self, token_translator, arg):
-    for k, vals in arg.iteritems():
+    for k, vals in six.iteritems(arg):
       arg[k] = [token_translator.convert_base64_string(v) for v in vals]
 
 
@@ -127,7 +154,7 @@ class ZincAnalysis(object):
 
   # Implementation of class method required by Analysis.
 
-  FORMAT_VERSION_LINE = 'format version: 5\n'
+  FORMAT_VERSION_LINE = b'format version: 5\n'
 
   @staticmethod
   def merge_disjoint_dicts(dicts):
@@ -150,7 +177,7 @@ class ZincAnalysis(object):
     """
     ret = defaultdict(list)
     for d in dicts:
-      for k, v in d.items():
+      for k, v in six.iteritems(d):
         if k not in ret or ret[k] < v:
           ret[k] = v
     return ret
@@ -179,11 +206,11 @@ class ZincAnalysis(object):
       naive_external = ZincAnalysis.merge_disjoint_dicts(externals)
 
       # Note that we take care not to create empty values in internal.
-      for k, vs in naive_internal.items():
+      for k, vs in six.iteritems(naive_internal):
         if vs:
           internal[k].extend(vs)  # Ensure a new list.
 
-      for k, vs in naive_external.items():
+      for k, vs in six.iteritems(naive_external):
         # class->source is many->one, so make sure we only internalize a source once.
         internal_k = set(internal.get(k, []))
         for v in vs:
@@ -230,7 +257,7 @@ class ZincAnalysis(object):
     internal_apis = ZincAnalysis.merge_disjoint_dicts([a.apis.internal for a in analyses])
     naive_external_apis = ZincAnalysis.merge_disjoint_dicts([a.apis.external for a in analyses])
     external_apis = defaultdict(list)
-    for k, vs in naive_external_apis.items():
+    for k, vs in six.iteritems(naive_external_apis):
       kfile = class_to_source.get(k)
       if kfile and kfile in src_prod:
         internal_apis[kfile] = vs  # Internalized.
@@ -242,10 +269,10 @@ class ZincAnalysis(object):
     source_infos = SourceInfos((ZincAnalysis.merge_disjoint_dicts([a.source_infos.source_infos for a in analyses]), ))
 
     # Merge compilations.
-    compilation_vals = sorted(set([x[0] for a in analyses for x in a.compilations.compilations.itervalues()]))
+    compilation_vals = sorted(set([x[0] for a in analyses for x in six.itervalues(a.compilations.compilations)]))
     compilations_dict = defaultdict(list)
     for i, v in enumerate(compilation_vals):
-      compilations_dict['{:03}'.format(int(i))] = [v]
+      compilations_dict[b'{:03}'.format(int(i))] = [v]
     compilations = Compilations((compilations_dict, ))
 
     return ZincAnalysis(compile_setup, relations, stamps, apis, source_infos, compilations)
@@ -285,109 +312,138 @@ class ZincAnalysis(object):
 
   # Implementation of methods required by Analysis.
 
-  def split(self, splits, buildroot, catchall=False):
+  def split(self, splits, catchall=False):
     # Note: correctly handles "externalizing" internal deps that must be external post-split.
-    splits = [set([s if os.path.isabs(s) else os.path.join(buildroot, s) for s in x]) for x in splits]
+    splits = [set(x) for x in splits]  # Ensure sets, for performance.
     if catchall:
       # Even empty sources with no products have stamps.
       remainder_sources = set(self.sources()).difference(*splits)
       splits.append(remainder_sources)  # The catch-all
 
+    # The inner functions are primarily for ease of performance profiling.
+
+    # For historical reasons, external deps are specified as src->class while internal deps are
+    # specified as src->src.  So when splitting we need to pick a representative.  We must pick
+    # consistently, so we take the first class name in alphanumeric order.
+    def make_representatives():
+      representatives = {k: min(vs) for k, vs in six.iteritems(self.relations.classes)}
+      return representatives
+    representatives = make_representatives()
+
+    # Split the source, binary and classes keys in our relations structs.
+    # Subsequent operations need this data.
+    def split_relation_keys():
+      src_prod_splits = self._split_dict(self.relations.src_prod, splits)
+      binary_dep_splits = self._split_dict(self.relations.binary_dep, splits)
+      classes_splits = self._split_dict(self.relations.classes, splits)
+      return src_prod_splits, binary_dep_splits, classes_splits
+    src_prod_splits, binary_dep_splits, classes_splits = split_relation_keys()
+
     # Split relations.
-    src_prod_splits = self._split_dict(self.relations.src_prod, splits)
-    binary_dep_splits = self._split_dict(self.relations.binary_dep, splits)
-    classes_splits = self._split_dict(self.relations.classes, splits)
+    def split_relations():
+      # Split a single pair of (internal, external) dependencies.
+      def _split_dependencies(all_internal, all_external):
+        internals = []
+        externals = []
 
-    representatives = {k: min(vs) for k, vs in self.relations.classes.items()}
+        naive_internals = self._split_dict(all_internal, splits)
+        naive_externals = self._split_dict(all_external, splits)
 
-    def split_dependencies(all_internal, all_external):
-      internals = []
-      externals = []
+        for naive_internal, naive_external, split in zip(naive_internals, naive_externals, splits):
+          internal = defaultdict(list)
+          external = defaultdict(list)
 
-      naive_internals = self._split_dict(all_internal, splits)
-      naive_externals = self._split_dict(all_external, splits)
+          # Note that we take care not to create empty values in external.
+          for k, vs in six.iteritems(naive_external):
+            if vs:
+              external[k].extend(vs)  # Ensure a new list.
 
-      for naive_internal, naive_external, split in zip(naive_internals, naive_externals, splits):
-        internal = defaultdict(list)
-        external = defaultdict(list)
+          for k, vs in six.iteritems(naive_internal):
+            for v in vs:
+              if v in split:
+                internal[k].append(v)  # Remains internal.
+              else:
+                external[k].append(representatives[v])  # Externalized.
+          internals.append(internal)
+          externals.append(external)
+        return internals, externals
 
-        # Note that we take care not to create empty values in external.
-        for k, vs in naive_external.items():
-          if vs:
-            external[k].extend(vs)  # Ensure a new list.
+      internal_splits, external_splits = \
+        _split_dependencies(self.relations.internal_src_dep, self.relations.external_dep)
+      internal_pi_splits, external_pi_splits = \
+        _split_dependencies(self.relations.internal_src_dep_pi, self.relations.external_dep_pi)
 
-        for k, vs in naive_internal.items():
-          for v in vs:
-            if v in split:
-              internal[k].append(v)  # Remains internal.
-            else:
-              external[k].append(representatives[v])  # Externalized.
-        internals.append(internal)
-        externals.append(external)
-      return internals, externals
+      member_ref_internal_splits, member_ref_external_splits = \
+        _split_dependencies(self.relations.member_ref_internal_dep, self.relations.member_ref_external_dep)
+      inheritance_internal_splits, inheritance_external_splits = \
+        _split_dependencies(self.relations.inheritance_internal_dep, self.relations.inheritance_external_dep)
+      used_splits = self._split_dict(self.relations.used, splits)
 
-    internal_splits, external_splits = \
-      split_dependencies(self.relations.internal_src_dep, self.relations.external_dep)
-    internal_pi_splits, external_pi_splits = \
-      split_dependencies(self.relations.internal_src_dep_pi, self.relations.external_dep_pi)
-
-    member_ref_internal_splits, member_ref_external_splits = \
-      split_dependencies(self.relations.member_ref_internal_dep, self.relations.member_ref_external_dep)
-    inheritance_internal_splits, inheritance_external_splits = \
-      split_dependencies(self.relations.inheritance_internal_dep, self.relations.inheritance_external_dep)
-    used_splits = self._split_dict(self.relations.used, splits)
-
-    relations_splits = []
-    for args in zip(src_prod_splits, binary_dep_splits,
-                    internal_splits, external_splits,
-                    internal_pi_splits, external_pi_splits,
-                    member_ref_internal_splits, member_ref_external_splits,
-                    inheritance_internal_splits, inheritance_external_splits,
-                    classes_splits, used_splits):
-      relations_splits.append(Relations(args))
+      relations_splits = []
+      for args in zip(src_prod_splits, binary_dep_splits,
+                      internal_splits, external_splits,
+                      internal_pi_splits, external_pi_splits,
+                      member_ref_internal_splits, member_ref_external_splits,
+                      inheritance_internal_splits, inheritance_external_splits,
+                      classes_splits, used_splits):
+        relations_splits.append(Relations(args))
+      return relations_splits
+    relations_splits = split_relations()
 
     # Split stamps.
-    stamps_splits = []
-    for src_prod, binary_dep, split in zip(src_prod_splits, binary_dep_splits, splits):
-      products_set = set(itertools.chain(*src_prod.values()))
-      binaries_set = set(itertools.chain(*binary_dep.values()))
-      products = dict((k, v) for k, v in self.stamps.products.items() if k in products_set)
-      sources = dict((k, v) for k, v in self.stamps.sources.items() if k in split)
-      binaries = dict((k, v) for k, v in self.stamps.binaries.items() if k in binaries_set)
-      classnames = dict((k, v) for k, v in self.stamps.classnames.items() if k in binaries_set)
-      stamps_splits.append(Stamps((products, sources, binaries, classnames)))
+    def split_stamps():
+      stamps_splits = []
+      sources_splits = self._split_dict(self.stamps.sources, splits)
+      for src_prod, binary_dep, sources in zip(src_prod_splits, binary_dep_splits, sources_splits):
+        products_set = set(itertools.chain(*six.itervalues(src_prod)))
+        binaries_set = set(itertools.chain(*six.itervalues(binary_dep)))
+        products, _ = self._restrict_dicts(products_set, self.stamps.products)
+        binaries, classnames = self._restrict_dicts(binaries_set, self.stamps.binaries,
+                                                    self.stamps.classnames)
+        stamps_splits.append(Stamps((products, sources, binaries, classnames)))
+      return stamps_splits
+    stamps_splits = split_stamps()
 
     # Split apis.
+    def split_apis():
+      # Externalized deps must copy the target's formerly internal API.
+      representative_to_internal_api = {}
+      for src, rep in six.iteritems(representatives):
+        representative_to_internal_api[rep] = self.apis.internal.get(src)
 
-    # Externalized deps must copy the target's formerly internal API.
-    representative_to_internal_api = {}
-    for src, rep in representatives.items():
-      representative_to_internal_api[rep] = self.apis.internal.get(src)
+      internal_api_splits = self._split_dict(self.apis.internal, splits)
 
-    internal_api_splits = self._split_dict(self.apis.internal, splits)
+      external_api_splits = []
+      for rel in relations_splits:
+        external_api = {}
+        for vs in six.itervalues(rel.external_dep):
+          for v in vs:
+            if v in representative_to_internal_api:  # This is an externalized dep.
+              external_api[v] = representative_to_internal_api[v]
+            else: # This is a dep that was already external.
+              external_api[v] = self.apis.external[v]
+        external_api_splits.append(external_api)
 
-    external_api_splits = []
-    for external in external_splits:
-      external_api = {}
-      for vs in external.values():
-        for v in vs:
-          if v in representative_to_internal_api:  # This is an externalized dep.
-            external_api[v] = representative_to_internal_api[v]
-          else: # This is a dep that was already external.
-            external_api[v] = self.apis.external[v]
-      external_api_splits.append(external_api)
-
-    apis_splits = []
-    for args in zip(internal_api_splits, external_api_splits):
-      apis_splits.append(APIs(args))
+      apis_splits = []
+      for args in zip(internal_api_splits, external_api_splits):
+        apis_splits.append(APIs(args))
+      return apis_splits
+    apis_splits = split_apis()
 
     # Split source infos.
-    source_info_splits = \
-      [SourceInfos((x, )) for x in self._split_dict(self.source_infos.source_infos, splits)]
+    def split_source_infos():
+      source_info_splits = \
+        [SourceInfos((x, )) for x in self._split_dict(self.source_infos.source_infos, splits)]
+      return source_info_splits
+    source_info_splits = split_source_infos()
 
-    analyses = []
-    for relations, stamps, apis, source_infos in zip(relations_splits, stamps_splits, apis_splits, source_info_splits):
-      analyses.append(ZincAnalysis(self.compile_setup, relations, stamps, apis, source_infos, self.compilations))
+    # Create the final ZincAnalysis instances from all these split pieces.
+    def create_analyses():
+      analyses = []
+      for relations, stamps, apis, source_infos in zip(relations_splits, stamps_splits, apis_splits, source_info_splits):
+        analyses.append(ZincAnalysis(self.compile_setup, relations, stamps, apis, source_infos, self.compilations))
+      return analyses
+    analyses = create_analyses()
 
     return analyses
 
@@ -430,6 +486,26 @@ class ZincAnalysis(object):
       ret.append(dict_split)
     return ret
 
+  def _restrict_dicts(self, keys, dict1, dict2=None):
+    """Returns a subdict of each input dict with its keys restricted to the given set.
+
+    Assumes that iterating over keys is much faster than iterating over the dicts. So use this
+    when keys is small compared to the total number of items in the dicts.
+
+    Note: the interface is a bit odd, and would be more general if we allowed an arbitrary
+    number of dicts. However in practice we only need this for 1 or 2 dicts, and this code
+    runs faster than if we had to iterate over a list of dicts in an inner loop.
+    """
+    ret1 = {}
+    ret2 = None if dict2 is None else {}
+    for k in keys:
+      if k in dict1:
+        ret1[k] = dict1[k]
+      if dict2 is not None and k in dict2:
+        ret2[k] = dict2[k]
+    return ret1, ret2
+
+
 class CompileSetup(ZincAnalysisElement):
   headers = ('output mode', 'output directories','compile options','javac options',
              'compiler version', 'compile order', 'name hashing')
@@ -444,19 +520,19 @@ class CompileSetup(ZincAnalysisElement):
     for k, vs in list(self.compile_options.items()):  # Make a copy, so we can del as we go.
       # Remove mentions of custom plugins.
       for v in vs:
-        if v.startswith('-Xplugin') or v.startswith('-P'):
+        if v.startswith(b'-Xplugin') or v.startswith(b'-P'):
           del self.compile_options[k]
 
 
 class Relations(ZincAnalysisElement):
-  headers = ('products', 'binary dependencies',
+  headers = (b'products', b'binary dependencies',
              # TODO: The following 4 headers will go away after SBT completes the
              # transition to the new headers (the 4 after that).
-             'direct source dependencies', 'direct external dependencies',
-             'public inherited source dependencies', 'public inherited external dependencies',
-             'member reference internal dependencies', 'member reference external dependencies',
-             'inheritance internal dependencies', 'inheritance external dependencies',
-             'class names', 'used names')
+             b'direct source dependencies', b'direct external dependencies',
+             b'public inherited source dependencies', b'public inherited external dependencies',
+             b'member reference internal dependencies', b'member reference external dependencies',
+             b'inheritance internal dependencies', b'inheritance external dependencies',
+             b'class names', b'used names')
 
   def __init__(self, args):
     super(Relations, self).__init__(args)
@@ -474,7 +550,7 @@ class Relations(ZincAnalysisElement):
 
 
 class Stamps(ZincAnalysisElement):
-  headers = ('product stamps', 'source stamps', 'binary stamps', 'class names')
+  headers = (b'product stamps', b'source stamps', b'binary stamps', b'class names')
 
   def __init__(self, args):
     super(Stamps, self).__init__(args)
@@ -501,7 +577,7 @@ class Stamps(ZincAnalysisElement):
 
 
 class APIs(ZincAnalysisElement):
-  headers = ('internal apis', 'external apis')
+  headers = (b'internal apis', b'external apis')
 
   def __init__(self, args):
     super(APIs, self).__init__(args)
@@ -514,7 +590,7 @@ class APIs(ZincAnalysisElement):
 
 
 class SourceInfos(ZincAnalysisElement):
-  headers = ("source infos", )
+  headers = (b'source infos', )
 
   def __init__(self, args):
     super(SourceInfos, self).__init__(args)
@@ -527,7 +603,7 @@ class SourceInfos(ZincAnalysisElement):
 
 
 class Compilations(ZincAnalysisElement):
-  headers = ('compilations', )
+  headers = (b'compilations', )
 
   def __init__(self, args):
     super(Compilations, self).__init__(args)

--- a/zincutils/zinc_analysis_diff.py
+++ b/zincutils/zinc_analysis_diff.py
@@ -25,8 +25,8 @@ class DictDiff(object):
     if not keys_only:
       shared_keys = left_keys & right_keys
       for key in shared_keys:
-        left_value = left_dict[key]
-        right_value = right_dict[key]
+        left_value = left_dict.get(key)
+        right_value = right_dict.get(key)
         if left_value != right_value:
           self._diff_keys[key] = (left_value, right_value)
 
@@ -35,14 +35,17 @@ class DictDiff(object):
 
   def __unicode__(self):
     parts = []
+    def decode_all(strs):
+      return [s.decode('utf-8') for s in strs]
     if self._left_missing_keys:
       parts.append('Keys missing from left but available in right: {}'
-                   .format(', '.join(self._left_missing_keys)))
+                   .format(', '.join(decode_all(self._left_missing_keys))))
     if self._right_missing_keys:
       parts.append('Keys available in left but missing from right: {}'
-                   .format(', '.join(self._right_missing_keys)))
+                   .format(', '.join(decode_all(self._right_missing_keys))))
     for k, vs in self._diff_keys.items():
-      parts.append('Different values for key {}: left has {}, right has {}'.format(k, vs[0], vs[1]))
+      parts.append('Different values for key {}: left has {}, right has {}'.format(
+        k.decode('utf-8'), decode_all(vs[0]), decode_all(vs[1])))
     return '\n'.join(parts)
 
   def __str__(self):

--- a/zincutils/zinc_analysis_parser.py
+++ b/zincutils/zinc_analysis_parser.py
@@ -44,14 +44,14 @@ class ZincAnalysisParser(object):
   def parse_products(self, infile):
     """An efficient parser of just the products section."""
     self._verify_version(infile)
-    return self._find_repeated_at_header(infile, 'products')
+    return self._find_repeated_at_header(infile, b'products')
 
   def parse_deps(self, infile, classes_dir):
     self._verify_version(infile)
     # Note: relies on the fact that these headers appear in this order in the file.
-    bin_deps = self._find_repeated_at_header(infile, 'binary dependencies')
-    src_deps = self._find_repeated_at_header(infile, 'direct source dependencies')
-    ext_deps = self._find_repeated_at_header(infile, 'direct external dependencies')
+    bin_deps = self._find_repeated_at_header(infile, b'binary dependencies')
+    src_deps = self._find_repeated_at_header(infile, b'direct source dependencies')
+    ext_deps = self._find_repeated_at_header(infile, b'direct external dependencies')
 
     # TODO(benjy): Temporary hack until we inject a dep on the scala runtime jar.
     scalalib_re = re.compile(r'scala-library-\d+\.\d+\.\d+\.jar$')
@@ -61,7 +61,7 @@ class ZincAnalysisParser(object):
 
     transformed_ext_deps = {}
     def fqcn_to_path(fqcn):
-      return os.path.join(classes_dir, fqcn.replace('.', os.sep) + '.class')
+      return os.path.join(classes_dir, fqcn.replace(b'.', os.sep) + b'.class')
     for src, fqcns in ext_deps.items():
       transformed_ext_deps[src] = [fqcn_to_path(fqcn) for fqcn in fqcns]
 
@@ -71,7 +71,7 @@ class ZincAnalysisParser(object):
     return ret
 
   def _find_repeated_at_header(self, lines_iter, header):
-    header_line = header + ':\n'
+    header_line = header + b':\n'
     while lines_iter.next() != header_line:
       pass
     return self._parse_section(lines_iter, expected_header=None)
@@ -85,12 +85,12 @@ class ZincAnalysisParser(object):
     """Parse a single section."""
     if expected_header:
       line = lines_iter.next()
-      if expected_header + ':\n' != line:
+      if expected_header + b':\n' != line:
         raise self.ParseError('Expected: "{}:". Found: "{}"'.format(expected_header, line))
     n = self._parse_num_items(lines_iter.next())
     relation = defaultdict(list)  # Values are lists, to accommodate relations.
     for i in range(n):
-      k, _, v = lines_iter.next().decode('utf-8').partition(' -> ')
+      k, _, v = lines_iter.next().partition(b' -> ')
       if len(v) == 1:  # Value on its own line.
         v = lines_iter.next()
       relation[k].append(v[:-1])


### PR DESCRIPTION
- Sorts entries only when needed for testing/debugging.
- Gets rid of all utf-8 decoding/encoding: Now keys and values are just
  byte arrays, which is fine since we never care about what they mean.
- Switch to iteritems(), iterkeys() and itervalues() everywhere.
- Write out large chunks, instead of calling file.write() on every
  little string fragment.
- Much faster implementation of restricting a large dict to
  a small subset of its keys.
- Also gets rid of the buildroot argument to split(): its use
  is more appropriately applied in the pants wrapping around this code.

All these changes yielded measurable improvements, even if some of them
seem counterintuitive.
