### PR TITLE
Force sorting for some sections.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ config = {
     'author': 'Pants Contributors',
     'url': 'https://pypi.python.org/pypi/zincutils',
     'author_email': 'pants-devel@groups.google.com',
-    'version': '0.2',
+    'version': '0.2.1',
     'install_requires': ['six'],
     'packages': ['zincutils'],
     'scripts': [],


### PR DESCRIPTION
It's probably not strictly necessary, but definitely less confusing
when debugging, for sections that are lists represented as maps
of index -> value to be sorted.

Also added tests to verify sorting behavior.
