### PR TITLE
Reimplement rebase functionality correctly.

### DIFF
--- a/tests/test_zinc_analysis.py
+++ b/tests/test_zinc_analysis.py
@@ -78,7 +78,7 @@ class ZincAnalysisTestSimple(ZincAnalysisTestBase):
         # text comparison because in some cases there can be small text differences that don't
         # affect logical equivalence.
         expected_analyis = parse_analyis(expected_filename)
-        self.assertTrue(expected_analyis == analysis_splits[i])
+        self.assertTrue(expected_analyis.is_equal_to(analysis_splits[i]))
 
         # Then compare as text.  In this simple case we expect them to be byte-for-byte equal.
         expected = get_analysis_text(expected_filename)
@@ -91,7 +91,7 @@ class ZincAnalysisTestSimple(ZincAnalysisTestBase):
       # Now merge and check that we get what we started with.
       merged_analysis = ZincAnalysis.merge(analysis_splits)
       # Check that they compare as objects.
-      self.assertTrue(full_analysis == merged_analysis)
+      self.assertTrue(full_analysis.is_equal_to(merged_analysis))
       # Check that they compare as text.
       expected = get_analysis_text('simple.analysis')
       actual = analysis_to_string(merged_analysis)
@@ -174,12 +174,12 @@ class ZincAnalysisTestComplex(ZincAnalysisTestBase):
 
         # Compare the merge result with the re-read one.
         diffs = merged_analysis.diff(merged_analysis2)
-        self.assertEquals(merged_analysis, merged_analysis2, ''.join(
+        self.assertTrue(merged_analysis.is_equal_to(merged_analysis2), ''.join(
           [unicode(diff) for diff in diffs]))
 
         # Compare the merge result with the expected.
         diffs = expected_merged_analysis.diff(merged_analysis2)
-        self.assertEquals(expected_merged_analysis, merged_analysis2, ''.join(
+        self.assertTrue(expected_merged_analysis.is_equal_to(merged_analysis2), ''.join(
           [unicode(diff) for diff in diffs]))
 
         # Split the merged analysis back to individual analyses.
@@ -212,7 +212,8 @@ class ZincAnalysisTestComplex(ZincAnalysisTestBase):
           #
           # This comparison works here only because we've taken care to prepare test data for which
           # it should hold. See _generate_testworthy_splits below for how to do so.
-          self.assertEquals(analysis, split_analysis, ''.join([unicode(diff) for diff in diffs]))
+          self.assertTrue(analysis.is_equal_to(split_analysis),
+                          ''.join([unicode(diff) for diff in diffs]))
 
       print('Total time: %f seconds' % self.total_time)
 

--- a/tests/testdata/simple/simple.rebased.analysis
+++ b/tests/testdata/simple/simple.rebased.analysis
@@ -1,0 +1,105 @@
+format version: 5
+output mode:
+1 items
+0 -> single
+output directories:
+1 items
+output dir -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes
+compile options:
+5 items
+0 -> -encoding
+1 -> UTF-8
+2 -> -g:vars
+3 -> -deprecation
+4 -> -unchecked
+javac options:
+0 items
+compiler version:
+1 items
+0 -> 2.10.4
+compile order:
+1 items
+0 -> Mixed
+name hashing:
+1 items
+0 -> false
+products:
+6 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$$anonfun$main$1.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$$anonfun$apply$1.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome.class
+binary dependencies:
+5 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> /Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/jre/lib/rt.jar
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> /Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/jre/lib/rt.jar
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/java/classes/org/pantsbuild/example/hello/greet/Greeting.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar
+direct source dependencies:
+1 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala
+direct external dependencies:
+0 items
+public inherited source dependencies:
+0 items
+public inherited external dependencies:
+0 items
+member reference internal dependencies:
+0 items
+member reference external dependencies:
+0 items
+inheritance internal dependencies:
+0 items
+inheritance external dependencies:
+0 items
+class names:
+6 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> org.pantsbuild.example.hello.exe.Exe
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> org.pantsbuild.example.hello.exe.Exe$
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> org.pantsbuild.example.hello.exe.Exe$$anonfun$main$1
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> org.pantsbuild.example.hello.welcome.Welcome
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> org.pantsbuild.example.hello.welcome.Welcome$
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> org.pantsbuild.example.hello.welcome.Welcome$$anonfun$apply$1
+used names:
+0 items
+product stamps:
+6 items
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$$anonfun$main$1.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe.class -> lastModified(1426908124000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$$anonfun$apply$1.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome.class -> lastModified(1426908125000)
+source stamps:
+2 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> hash(7c960d05aac5b607c6e0619bb6b81b6ca580550e)
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> hash(2245c9e68457b389bac32ccaa0dca5ddadd8f1da)
+binary stamps:
+3 items
+/Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/jre/lib/rt.jar -> lastModified(1422417173000)
+$PANTS_HOME/.pants.d/compile/jvm/java/classes/org/pantsbuild/example/hello/greet/Greeting.class -> lastModified(1426908117000)
+$PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar -> lastModified(1395179187000)
+class names:
+3 items
+/Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/jre/lib/rt.jar -> java.lang.Object
+$PANTS_HOME/.pants.d/compile/jvm/java/classes/org/pantsbuild/example/hello/greet/Greeting.class -> org.pantsbuild.example.hello.greet.Greeting
+$PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar -> scala.collection.TraversableLike
+internal apis:
+2 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> 
+FakeApiForExe
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> 
+FakeApiForWelcome
+external apis:
+0 items
+source infos:
+2 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> 
+FakeSourceInfoForExe
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> 
+FakeSourceInfoForWelcome
+compilations:
+0 items

--- a/tests/testdata/simple/simple.rebased.filtered.analysis
+++ b/tests/testdata/simple/simple.rebased.filtered.analysis
@@ -1,0 +1,101 @@
+format version: 5
+output mode:
+1 items
+0 -> single
+output directories:
+1 items
+output dir -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes
+compile options:
+5 items
+0 -> -encoding
+1 -> UTF-8
+2 -> -g:vars
+3 -> -deprecation
+4 -> -unchecked
+javac options:
+0 items
+compiler version:
+1 items
+0 -> 2.10.4
+compile order:
+1 items
+0 -> Mixed
+name hashing:
+1 items
+0 -> false
+products:
+6 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$$anonfun$main$1.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$$anonfun$apply$1.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome.class
+binary dependencies:
+3 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/compile/jvm/java/classes/org/pantsbuild/example/hello/greet/Greeting.class
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> $PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar
+direct source dependencies:
+1 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> $PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala
+direct external dependencies:
+0 items
+public inherited source dependencies:
+0 items
+public inherited external dependencies:
+0 items
+member reference internal dependencies:
+0 items
+member reference external dependencies:
+0 items
+inheritance internal dependencies:
+0 items
+inheritance external dependencies:
+0 items
+class names:
+6 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> org.pantsbuild.example.hello.exe.Exe
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> org.pantsbuild.example.hello.exe.Exe$
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> org.pantsbuild.example.hello.exe.Exe$$anonfun$main$1
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> org.pantsbuild.example.hello.welcome.Welcome
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> org.pantsbuild.example.hello.welcome.Welcome$
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> org.pantsbuild.example.hello.welcome.Welcome$$anonfun$apply$1
+used names:
+0 items
+product stamps:
+6 items
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$$anonfun$main$1.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe$.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/exe/Exe.class -> lastModified(1426908124000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$$anonfun$apply$1.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome$.class -> lastModified(1426908125000)
+$PANTS_HOME/.pants.d/compile/jvm/scala/classes/org/pantsbuild/example/hello/welcome/Welcome.class -> lastModified(1426908125000)
+source stamps:
+2 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> hash(7c960d05aac5b607c6e0619bb6b81b6ca580550e)
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> hash(2245c9e68457b389bac32ccaa0dca5ddadd8f1da)
+binary stamps:
+2 items
+$PANTS_HOME/.pants.d/compile/jvm/java/classes/org/pantsbuild/example/hello/greet/Greeting.class -> lastModified(1426908117000)
+$PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar -> lastModified(1395179187000)
+class names:
+2 items
+$PANTS_HOME/.pants.d/compile/jvm/java/classes/org/pantsbuild/example/hello/greet/Greeting.class -> org.pantsbuild.example.hello.greet.Greeting
+$PANTS_HOME/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar -> scala.collection.TraversableLike
+internal apis:
+2 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> 
+FakeApiForExe
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> 
+FakeApiForWelcome
+external apis:
+0 items
+source infos:
+2 items
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala -> 
+FakeSourceInfoForExe
+$PANTS_HOME/examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala -> 
+FakeSourceInfoForWelcome
+compilations:
+0 items

--- a/zincutils/zinc_analysis.py
+++ b/zincutils/zinc_analysis.py
@@ -162,11 +162,15 @@ class ZincAnalysis(object):
   def sources(self):
     return self.stamps.sources.keys()
 
-  def __eq__(self, other):
-    return ((self.compile_setup, self.relations, self.stamps, self.apis,
-             self.source_infos, self.compilations) ==
-            (other.compile_setup, other.relations, other.stamps, other.apis,
-             other.source_infos, other.compilations))
+  def is_equal_to(self, other):
+    for self_element, other_element in zip(
+        (self.compile_setup, self.relations, self.stamps, self.apis,
+         self.source_infos, self.compilations),
+        (other.compile_setup, other.relations, other.stamps, other.apis,
+         other.source_infos, other.compilations)):
+      if not self_element.is_equal_to(other_element):
+        return False
+    return True
 
   def __ne__(self, other):
     return not self.__eq__(other)
@@ -313,7 +317,7 @@ class ZincAnalysis(object):
     return analyses
 
   def write_to_path(self, outfile_path):
-    with open(outfile_path, 'w') as outfile:
+    with open(outfile_path, 'wb') as outfile:
       self.write(outfile)
 
   def write(self, outfile):

--- a/zincutils/zinc_analysis_element.py
+++ b/zincutils/zinc_analysis_element.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import six
+from collections import defaultdict
+
+from zincutils.zinc_analysis_diff import ZincAnalysisElementDiff
+
+
+class ZincAnalysisElement(object):
+  """Encapsulates one part of a Zinc analysis.
+
+  Zinc analysis files are text files consisting of sections. Each section is introduced by
+  a header, followed by lines of the form K -> V, where the same K may repeat multiple times.
+
+  For example, the 'products:' section maps source files to the class files it produces, e.g.,
+
+  products:
+  123 items
+  org/pantsbuild/Foo.scala -> org/pantsbuild/Foo.class
+  org/pantsbuild/Foo.scala -> org/pantsbuild/Foo$.class
+  ...
+
+  Related consecutive sections are bundled together in "elements". E.g., the Stamps element
+  bundles the section for source file stamps, the section for jar file stamps etc.
+
+  An instance of this class represents such an element.
+  """
+  # Whether values in this element are written inline, i.e., key -> val, or not, i.e., key -> \nval.
+  inline_vals = True
+
+  # The section names for the sections in this element. Subclasses override.
+  headers = ()
+
+  # The following are tuples of section names in this element to which different forms of rebasing
+  # logic apply. Subclasses may override to have rebasing logic applied appropriately to the
+  # relevant section. This makes rebasing far more efficient than blindly string-replacing
+  # everywhere.
+
+  # Sections that can reference paths under the pants home anywhere on a line.
+  # To rebase pants home we must string-replace anywhere in the line.
+  pants_home_anywhere = ()
+
+  # Sections that can reference paths under the pants home, but only at the beginning of a line.
+  # To rebase pants home we can just check the prefix.
+  pants_home_prefix_only = ()
+
+  # Sections that can reference paths under the jvm home anywhere on a line.
+  # To filter out lines with jvm home references we must search the entire line.
+  java_home_anywhere = ()
+
+  # Sections that can reference paths under the jvm home, but only at the beginning of a line.
+  # To filter out lines with jvm home references we need check the prefix.
+  java_home_prefix_only = ()
+
+  def __init__(self, args, always_sort=False):
+    """
+    :param args: A list of maps from key to list of values.
+    :param always_sort: If True, sections are always sorted. Otherwise they are only sorted
+                        if the environment variable ZINCUTILS_SORTED_ANALYSIS is set.
+
+    Each map in ``args`` corresponds to a section in the analysis file. E.g.,
+
+    'org/pantsbuild/Foo.scala': ['org/pantsbuild/Foo.class', 'org/pantsbuild/Foo$.class']
+
+    Subclasses can alias the elements of self.args in their own __init__, for convenience.
+    """
+    self._always_sort = always_sort
+    if self.should_be_sorted():
+      self.args = []
+      for arg in args:
+        sorted_arg = defaultdict(list)
+        for k, vs in arg.items():
+          sorted_arg[k] = sorted(vs)
+        self.args.append(sorted_arg)
+    else:
+      self.args = args
+
+  def diff(self, other):
+    return ZincAnalysisElementDiff(self, other)
+
+  def should_be_sorted(self):
+    return self._always_sort or os.environ.get('ZINCUTILS_SORTED_ANALYSIS')
+
+  def __eq__(self, other):
+    # Expects keys and vals to be sorted.
+    return self.args == other.args
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+  def __hash__(self):
+    return hash(self.args)
+
+  def write(self, outfile):
+    self._write_multiple_sections(outfile, self.headers, self.args)
+
+  def _write_multiple_sections(self, outfile, headers, reps):
+    """Write multiple sections."""
+    for header, rep in zip(headers, reps):
+      self._write_section(outfile, header, rep)
+
+  def _write_section(self, outfile, header, rep):
+    """Write a single section.
+
+    Items are sorted, for ease of testing, only if ZINCUTILS_SORTED_ANALYSIS is set in
+    the environment, and is not falsy. The sort is too costly to have in production use.
+    """
+    num_items = 0
+    for vals in six.itervalues(rep):
+      num_items += len(vals)
+
+    outfile.write(header + b':\n')
+    outfile.write(b'{} items\n'.format(num_items))
+
+    # Writing in large chunks is significantly faster than writing line-by-line.
+    fragments = []
+    def do_write():
+      buf = b''.join(fragments)
+      outfile.write(buf)
+      del fragments[:]
+
+    if self.should_be_sorted():
+      # Write everything in a single chunk, so we can sort.
+      for k, vals in six.iteritems(rep):
+        for v in vals:
+          item = b'{} -> {}{}\n'.format(k, b'' if self.inline_vals else b'\n', v)
+          fragments.append(item)
+      fragments.sort()
+      do_write()
+    else:
+      # It's not strictly necessary to chunk on item boundaries, but it's nicer.
+      chunk_size = 40000 if self.inline_vals else 50000
+      for k, vals in six.iteritems(rep):
+        for v in vals:
+          fragments.append(k)
+          fragments.append(b' -> ')
+          if not self.inline_vals:
+            fragments.append(b'\n')
+          fragments.append(v)
+          fragments.append(b'\n')
+        if len(fragments) >= chunk_size:
+          do_write()
+      do_write()
+
+  def translate_keys(self, token_translator, arg):
+    old_keys = list(six.iterkeys(arg))
+    for k in old_keys:
+      vals = arg[k]
+      del arg[k]
+      arg[token_translator.convert(k)] = vals
+
+  def translate_values(self, token_translator, arg):
+    for k, vals in six.iteritems(arg):
+      arg[k] = [token_translator.convert(v) for v in vals]
+
+  def translate_base64_values(self, token_translator, arg):
+    for k, vals in six.iteritems(arg):
+      arg[k] = [token_translator.convert_base64_string(v) for v in vals]

--- a/zincutils/zinc_analysis_element.py
+++ b/zincutils/zinc_analysis_element.py
@@ -87,15 +87,11 @@ class ZincAnalysisElement(object):
   def should_be_sorted(self):
     return self._always_sort or os.environ.get('ZINCUTILS_SORTED_ANALYSIS')
 
-  def __eq__(self, other):
-    # Expects keys and vals to be sorted.
+  def is_equal_to(self, other):
+    # Is sensitive to ordering of keys and vals. Will NOT WORK as expected unless
+    # should_be_sorted() returns True for both self and other.  So only call this
+    # in tests, where you're guaranteeing that sorting.
     return self.args == other.args
-
-  def __ne__(self, other):
-    return not self.__eq__(other)
-
-  def __hash__(self):
-    return hash(self.args)
 
   def write(self, outfile):
     self._write_multiple_sections(outfile, self.headers, self.args)
@@ -111,9 +107,7 @@ class ZincAnalysisElement(object):
     Items are sorted, for ease of testing, only if ZINCUTILS_SORTED_ANALYSIS is set in
     the environment, and is not falsy. The sort is too costly to have in production use.
     """
-    num_items = 0
-    for vals in six.itervalues(rep):
-      num_items += len(vals)
+    num_items = sum(len(vals) for vals in six.itervalues(rep))
 
     outfile.write(header + b':\n')
     outfile.write(b'{} items\n'.format(num_items))

--- a/zincutils/zinc_analysis_element_types.py
+++ b/zincutils/zinc_analysis_element_types.py
@@ -1,0 +1,159 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from zincutils.zinc_analysis_diff import ZincAnalysisElementDiff
+from zincutils.zinc_analysis_element import ZincAnalysisElement
+
+
+class CompileSetup(ZincAnalysisElement):
+  headers = ('output mode', 'output directories','compile options','javac options',
+             'compiler version', 'compile order', 'name hashing')
+
+  # Output directories can obviously contain directories under pants_home. Compile/javac options may
+  # refer to directories under pants_home.
+  pants_home_anywhere = ('output directories','compile options','javac options')
+
+  def __init__(self, args):
+    # Most sections in CompileSetup are arrays represented as maps from index to item:
+    #   0 -> item0
+    #   1 -> item1
+    #   ...
+    #
+    # We ensure these are sorted, in case any reading code makes assumptions about the order.
+    # These are very small sections, so there's no performance impact to sorting them.
+    super(CompileSetup, self).__init__(args, always_sort=True)
+    (self.output_mode, self.output_dirs, self.compile_options, self.javac_options,
+     self.compiler_version, self.compile_order, self.name_hashing) = self.args
+
+  def translate(self, token_translator):
+    self.translate_values(token_translator, self.output_dirs)
+    for k, vs in list(self.compile_options.items()):  # Make a copy, so we can del as we go.
+      # Remove mentions of custom plugins.
+      for v in vs:
+        if v.startswith(b'-Xplugin') or v.startswith(b'-P'):
+          del self.compile_options[k]
+
+
+class Relations(ZincAnalysisElement):
+  headers = (b'products', b'binary dependencies',
+             # TODO: The following 4 headers will go away after SBT completes the
+             # transition to the new headers (the 4 after that).
+             b'direct source dependencies', b'direct external dependencies',
+             b'public inherited source dependencies', b'public inherited external dependencies',
+             b'member reference internal dependencies', b'member reference external dependencies',
+             b'inheritance internal dependencies', b'inheritance external dependencies',
+             b'class names', b'used names')
+
+  # Products are src->classfile, binary dependencies are src->jarfile, source/internal dependencies are src->src,
+  # TODO: Check if 'used names' really needs to be in pants_home_anywhere, or can it be in pants_home_prefix_only?
+  pants_home_anywhere = (b'products', b'binary dependencies',
+                         b'direct source dependencies', b'public inherited source dependencies',
+                         b'member reference internal dependencies', b'inheritance internal dependencies',
+                         b'used names')
+  # External dependencies and class names are src->fqcn.
+  pants_home_prefix_only = (b'direct external dependencies', b'public inherited external dependencies',
+                            b'member reference external dependencies',  b'inheritance external dependencies',
+                            b'class names')
+  # Binary dependencies are src->jarfile, and that jarfile might be under the jvm home.
+  java_home_anywhere = (b'binary dependencies',)
+
+  def __init__(self, args):
+    super(Relations, self).__init__(args)
+    (self.src_prod, self.binary_dep,
+     self.internal_src_dep, self.external_dep,
+     self.internal_src_dep_pi, self.external_dep_pi,
+     self.member_ref_internal_dep, self.member_ref_external_dep,
+     self.inheritance_internal_dep, self.inheritance_external_dep,
+     self.classes, self.used) = self.args
+
+  def translate(self, token_translator):
+    for a in self.args:
+      self.translate_values(token_translator, a)
+      self.translate_keys(token_translator, a)
+
+
+class Stamps(ZincAnalysisElement):
+  headers = (b'product stamps', b'source stamps', b'binary stamps', b'class names')
+
+  # All sections are src/class/jar file->stamp.
+  pants_home_prefix_only = headers
+  # Only these sections can reference jar files under the jvm home.
+  java_home_prefix_only = (b'binary stamps', b'class names')
+
+  def __init__(self, args):
+    super(Stamps, self).__init__(args)
+    (self.products, self.sources, self.binaries, self.classnames) = self.args
+
+  def translate(self, token_translator):
+    for a in self.args:
+      self.translate_keys(token_translator, a)
+    self.translate_values(token_translator, self.classnames)
+
+  # We make equality ignore the values in classnames: classnames is a map from
+  # jar file to one representative class in that jar, and the representative can change.
+  # However this doesn't affect any useful aspect of the analysis, so we ignore it.
+
+  def diff(self, other):
+    return ZincAnalysisElementDiff(self, other, keys_only_headers=('class names', ))
+
+  def __eq__(self, other):
+    return (self.products, self.sources, self.binaries, set(self.classnames.keys())) == \
+           (other.products, other.sources, other.binaries, set(other.classnames.keys()))
+
+  def __hash__(self):
+    return hash((self.products, self.sources, self.binaries, self.classnames.keys()))
+
+
+class APIs(ZincAnalysisElement):
+  inline_vals = False
+
+  headers = (b'internal apis', b'external apis')
+
+  # Internal apis are src->blob, but external apis are fqcn->blob, so we don't need to rebase them.
+  pants_home_prefix_only = (b'internal apis',)
+
+  def __init__(self, args):
+    super(APIs, self).__init__(args)
+    (self.internal, self.external) = self.args
+
+  def translate(self, token_translator):
+    for a in self.args:
+      self.translate_base64_values(token_translator, a)
+      self.translate_keys(token_translator, a)
+
+
+class SourceInfos(ZincAnalysisElement):
+  inline_vals = False
+
+  headers = (b'source infos', )
+
+  # Source infos are src->blob.
+  pants_home_prefix_only = headers
+
+  def __init__(self, args):
+    super(SourceInfos, self).__init__(args)
+    (self.source_infos, ) = self.args
+
+  def translate(self, token_translator):
+    for a in self.args:
+      self.translate_base64_values(token_translator, a)
+      self.translate_keys(token_translator, a)
+
+
+class Compilations(ZincAnalysisElement):
+  headers = (b'compilations', )
+
+  def __init__(self, args):
+    super(Compilations, self).__init__(args)
+    (self.compilations, ) = self.args
+    # Compilations aren't useful and can accumulate to be huge and drag down parse times.
+    # We clear them here to prevent them propagating through splits/merges.
+    self.compilations.clear()
+
+  def translate(self, token_translator):
+    pass
+

--- a/zincutils/zinc_analysis_element_types.py
+++ b/zincutils/zinc_analysis_element_types.py
@@ -10,12 +10,12 @@ from zincutils.zinc_analysis_element import ZincAnalysisElement
 
 
 class CompileSetup(ZincAnalysisElement):
-  headers = ('output mode', 'output directories','compile options','javac options',
+  headers = ('output mode', 'output directories', 'compile options', 'javac options',
              'compiler version', 'compile order', 'name hashing')
 
   # Output directories can obviously contain directories under pants_home. Compile/javac options may
   # refer to directories under pants_home.
-  pants_home_anywhere = ('output directories','compile options','javac options')
+  pants_home_anywhere = ('output directories', 'compile options', 'javac options')
 
   def __init__(self, args):
     # Most sections in CompileSetup are arrays represented as maps from index to item:
@@ -56,7 +56,7 @@ class Relations(ZincAnalysisElement):
                          b'used names')
   # External dependencies and class names are src->fqcn.
   pants_home_prefix_only = (b'direct external dependencies', b'public inherited external dependencies',
-                            b'member reference external dependencies',  b'inheritance external dependencies',
+                            b'member reference external dependencies', b'inheritance external dependencies',
                             b'class names')
   # Binary dependencies are src->jarfile, and that jarfile might be under the jvm home.
   java_home_anywhere = (b'binary dependencies',)

--- a/zincutils/zinc_analysis_parser.py
+++ b/zincutils/zinc_analysis_parser.py
@@ -23,7 +23,7 @@ class ZincAnalysisParser(object):
 
   def parse_from_path(self, infile_path):
     """Parse a ZincAnalysis instance from a text file."""
-    with open(infile_path, 'r') as infile:
+    with open(infile_path, 'rb') as infile:
       return self.parse(infile)
 
   def parse(self, infile):
@@ -71,8 +71,8 @@ class ZincAnalysisParser(object):
     return ret
 
   def rebase_from_path(self, infile_path, outfile_path, pants_home_from, pants_home_to, java_home=None):
-    with open(infile_path, 'r') as infile:
-      with open(outfile_path, 'w') as outfile:
+    with open(infile_path, 'rb') as infile:
+      with open(outfile_path, 'wb') as outfile:
         self.rebase(infile, outfile, pants_home_from, pants_home_to, java_home)
 
   def rebase(self, infile, outfile, pants_home_from, pants_home_to, java_home=None):


### PR DESCRIPTION
It was previously implemented naively: fully parse the analysis file,
then rewrite lines as they're written out.

It was also implemented too generally: allowing any number of rebasings,
whereas we only actually need a single rewrite (of pants home to/from a
placeholder) and, optionally, a single filter (of any lines containing
paths under java home).

This new implementation is much more selective and more efficient:
- Each section now declares whether its lines need the rewrite, the filter or both.
  It also declares whether the entire line needs to be examined, or whether
  it's enough to just match at the start of the line.
- Instead of fully parsing the file, which is slow, rebasing now just
  rips over the lines and acts on them as text.

Also split ZincAnalysisElement into its own file, and its subclasses into
their own file, as zinc_analysis.py was getting quite huge.
